### PR TITLE
test: Add mocking facility to test updating of file content

### DIFF
--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -345,6 +345,21 @@ describe('OnCompletion-ToLogFile', () => {
         // Because the updated task is not DONE, no file output should have been written:
         expect(capturedUpdatedData).toBeUndefined();
     });
+
+    it('should append a recurring task to end of an existing file', () => {
+        // Arrange
+        const line = '- [ ] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-11';
+
+        const simulatedData = '# Existing heading - without end-of-line';
+        const newStatus = Status.makeDone();
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
+
+        // Assert
+        expect(toMarkdown(tasks)).toEqual('- [ ] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-12');
+        expect(capturedUpdatedData).toBe(`# Existing heading - without end-of-line
+- [x] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-11 ✅ 2024-02-11
+`);
+    });
 });
 
 describe('OnCompletion-EndOfList', () => {

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -310,11 +310,12 @@ describe('OnCompletion-ToLogFile', () => {
         const task = new TaskBuilder().description('A non-recurring task with 🏁 ToLogFile').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
+        const simulatedData = ''; // Example initial data
+
         let capturedUpdatedData; // Variable to capture the updated data
 
         // Create a Jest spy for the file writer
         const mockFileWriter = jest.fn((_filePath: string, fileContentUpdater: (data: string) => string) => {
-            const simulatedData = ''; // Example initial data
             capturedUpdatedData = fileContentUpdater(simulatedData); // Execute updater function and capture the result
         });
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -319,8 +319,7 @@ function setupTestAndCaptureData(task: Task, newStatus: Status, simulatedData: s
 describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
-        const dueDate = '2024-02-10';
-        const task = new TaskBuilder().description('A non-recurring task with 🏁 ToLogFile').dueDate(dueDate).build();
+        const task = fromLine({ line: '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10' });
 
         const simulatedData = ''; // Example initial data
         const newStatus = Status.makeDone();

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -303,6 +303,19 @@ export function applyStatusAndOnCompletionAction2(
     return handleOnCompletion(task, tasks, 'archive.md', fileWriter);
 }
 
+function setupTestAndCaptureData(task: Task, newStatus: Status, simulatedData: string) {
+    let capturedUpdatedData; // Variable to capture the updated data
+
+    // Create a Jest spy for the file writer
+    const mockFileWriter = jest.fn((_filePath: string, fileContentUpdater: (data: string) => string) => {
+        capturedUpdatedData = fileContentUpdater(simulatedData); // Execute updater function and capture the result
+    });
+
+    // Act
+    const tasks = applyStatusAndOnCompletionAction2(task, newStatus, mockFileWriter);
+    return { capturedUpdatedData, mockFileWriter, tasks };
+}
+
 describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
@@ -312,16 +325,7 @@ describe('OnCompletion-ToLogFile', () => {
 
         const simulatedData = ''; // Example initial data
         const newStatus = Status.makeDone();
-
-        let capturedUpdatedData; // Variable to capture the updated data
-
-        // Create a Jest spy for the file writer
-        const mockFileWriter = jest.fn((_filePath: string, fileContentUpdater: (data: string) => string) => {
-            capturedUpdatedData = fileContentUpdater(simulatedData); // Execute updater function and capture the result
-        });
-
-        // Act
-        const tasks = applyStatusAndOnCompletionAction2(task, newStatus, mockFileWriter);
+        const { capturedUpdatedData, mockFileWriter, tasks } = setupTestAndCaptureData(task, newStatus, simulatedData);
 
         // Assert
         expect(tasks).toEqual([]);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -303,7 +303,8 @@ export function applyStatusAndOnCompletionAction2(
     return handleOnCompletion(task, tasks, 'archive.md', fileWriter);
 }
 
-function setupTestAndCaptureData(task: Task, newStatus: Status, simulatedData: string) {
+function setupTestAndCaptureData(line: string, _task: Task, newStatus: Status, simulatedData: string) {
+    const task = fromLine({ line: line });
     let capturedUpdatedData; // Variable to capture the updated data
 
     // Create a Jest spy for the file writer
@@ -319,11 +320,12 @@ function setupTestAndCaptureData(task: Task, newStatus: Status, simulatedData: s
 describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
-        const task = fromLine({ line: '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10' });
+        const line = '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10';
+        const task = fromLine({ line: line });
 
         const simulatedData = ''; // Example initial data
         const newStatus = Status.makeDone();
-        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(task, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, task, newStatus, simulatedData);
 
         // Assert
         expect(tasks).toEqual([]);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -322,8 +322,7 @@ describe('OnCompletion-ToLogFile', () => {
         const line = '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10';
 
         const simulatedData = ''; // Example initial data
-        const newStatus = Status.makeDone();
-        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeDone(), simulatedData);
 
         // Assert
         expect(tasks).toEqual([]);
@@ -336,8 +335,7 @@ describe('OnCompletion-ToLogFile', () => {
         const line = '- [x] A task that was DONE 🏁 ToLogFile';
 
         const simulatedData = ''; // Example initial data
-        const newStatus = Status.makeTodo();
-        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeTodo(), simulatedData);
 
         // Assert
         expect(toMarkdown(tasks)).toEqual('- [ ] A task that was DONE 🏁 ToLogFile');
@@ -350,8 +348,7 @@ describe('OnCompletion-ToLogFile', () => {
         const line = '- [ ] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-11';
 
         const simulatedData = '# Existing heading - without end-of-line';
-        const newStatus = Status.makeDone();
-        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeDone(), simulatedData);
 
         // Assert
         expect(toMarkdown(tasks)).toEqual('- [ ] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-12');

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -331,6 +331,20 @@ describe('OnCompletion-ToLogFile', () => {
         expect(capturedUpdatedData).toBe(`- [x] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10 ✅ 2024-02-11
 `);
     });
+
+    it('should not update any file if task is not completed', () => {
+        // Arrange
+        const line = '- [x] A task that was DONE 🏁 ToLogFile';
+
+        const simulatedData = ''; // Example initial data
+        const newStatus = Status.makeTodo();
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
+
+        // Assert
+        expect(toMarkdown(tasks)).toEqual('- [ ] A task that was DONE 🏁 ToLogFile');
+        // Because the updated task is not DONE, no file output should have been written:
+        expect(capturedUpdatedData).toBeUndefined();
+    });
 });
 
 describe('OnCompletion-EndOfList', () => {

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -9,8 +9,7 @@ import { StatusConfiguration, StatusType } from '../../src/Statuses/StatusConfig
 import { TaskBuilder } from '../TestingTools/TaskBuilder';
 import { fromLine, toLines, toMarkdown } from '../TestingTools/TestHelpers';
 import type { Task } from '../../src/Task/Task';
-import { handleOnCompletion } from '../../src/Task/OnCompletion';
-import { writeLineToListEnd } from '../../src/Task/OnCompletion';
+import { handleOnCompletion, writeLineToListEnd } from '../../src/Task/OnCompletion';
 
 window.moment = moment;
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -320,8 +320,9 @@ describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
         const line = '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10';
-
         const simulatedData = ''; // Example initial data
+
+        // Act
         const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeDone(), simulatedData);
 
         // Assert
@@ -333,8 +334,9 @@ describe('OnCompletion-ToLogFile', () => {
     it('should not update any file if task is not completed', () => {
         // Arrange
         const line = '- [x] A task that was DONE 🏁 ToLogFile';
-
         const simulatedData = ''; // Example initial data
+
+        // Act
         const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeTodo(), simulatedData);
 
         // Assert
@@ -346,8 +348,9 @@ describe('OnCompletion-ToLogFile', () => {
     it('should append a recurring task to end of an existing file', () => {
         // Arrange
         const line = '- [ ] Recurring task 🏁 ToLogFile 🔁 every day 📅 2024-02-11';
-
         const simulatedData = '# Existing heading - without end-of-line';
+
+        // Act
         const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, Status.makeDone(), simulatedData);
 
         // Assert

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -303,7 +303,7 @@ export function applyStatusAndOnCompletionAction2(
     return handleOnCompletion(task, tasks, 'archive.md', fileWriter);
 }
 
-function setupTestAndCaptureData(line: string, _task: Task, newStatus: Status, simulatedData: string) {
+function setupTestAndCaptureData(line: string, newStatus: Status, simulatedData: string) {
     const task = fromLine({ line: line });
     let capturedUpdatedData; // Variable to capture the updated data
 
@@ -321,11 +321,10 @@ describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
         const line = '- [ ] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10';
-        const task = fromLine({ line: line });
 
         const simulatedData = ''; // Example initial data
         const newStatus = Status.makeDone();
-        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, task, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(line, newStatus, simulatedData);
 
         // Assert
         expect(tasks).toEqual([]);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -310,27 +310,22 @@ describe('OnCompletion-ToLogFile', () => {
         const task = new TaskBuilder().description('A non-recurring task with 🏁 ToLogFile').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
+        let capturedUpdatedData; // Variable to capture the updated data
+
         // Create a Jest spy for the file writer
-        const mockFileWriter = jest.fn((_filePath: string, _fileContentUpdater: (data: string) => string) => {});
+        const mockFileWriter = jest.fn((_filePath: string, fileContentUpdater: (data: string) => string) => {
+            const simulatedData = ''; // Example initial data
+            capturedUpdatedData = fileContentUpdater(simulatedData); // Execute updater function and capture the result
+        });
 
         // Act
         const tasks = applyStatusAndOnCompletionAction2(task, Status.makeDone(), mockFileWriter);
 
         // Assert
         expect(tasks).toEqual([]);
-
-        // Check that mockFileWriter was called with the correct arguments
+        expect(mockFileWriter).toHaveBeenCalledTimes(1);
         expect(mockFileWriter).toHaveBeenCalledWith('archive.md', expect.any(Function));
-
-        // Check if mockFileWriter has been called
-        expect(mockFileWriter.mock.calls.length).toBe(1);
-        // Retrieve the fileContentUpdater function passed to mockFileWriter
-        const fileContentUpdater = mockFileWriter.mock.calls[0][1];
-
-        // Now simulate calling fileContentUpdater to check its behavior
-        const initiallyEmptyLogFile = '';
-        const updatedData = fileContentUpdater(initiallyEmptyLogFile);
-        expect(updatedData).toEqual(`- [x] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10 ✅ 2024-02-11
+        expect(capturedUpdatedData).toBe(`- [x] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10 ✅ 2024-02-11
 `);
     });
 });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -311,6 +311,7 @@ describe('OnCompletion-ToLogFile', () => {
         expect(task.status.type).toEqual(StatusType.TODO);
 
         const simulatedData = ''; // Example initial data
+        const newStatus = Status.makeDone();
 
         let capturedUpdatedData; // Variable to capture the updated data
 
@@ -320,7 +321,7 @@ describe('OnCompletion-ToLogFile', () => {
         });
 
         // Act
-        const tasks = applyStatusAndOnCompletionAction2(task, Status.makeDone(), mockFileWriter);
+        const tasks = applyStatusAndOnCompletionAction2(task, newStatus, mockFileWriter);
 
         // Assert
         expect(tasks).toEqual([]);

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -313,7 +313,7 @@ function setupTestAndCaptureData(task: Task, newStatus: Status, simulatedData: s
 
     // Act
     const tasks = applyStatusAndOnCompletionAction2(task, newStatus, mockFileWriter);
-    return { capturedUpdatedData, mockFileWriter, tasks };
+    return { capturedUpdatedData, tasks };
 }
 
 describe('OnCompletion-ToLogFile', () => {
@@ -321,16 +321,13 @@ describe('OnCompletion-ToLogFile', () => {
         // Arrange
         const dueDate = '2024-02-10';
         const task = new TaskBuilder().description('A non-recurring task with 🏁 ToLogFile').dueDate(dueDate).build();
-        expect(task.status.type).toEqual(StatusType.TODO);
 
         const simulatedData = ''; // Example initial data
         const newStatus = Status.makeDone();
-        const { capturedUpdatedData, mockFileWriter, tasks } = setupTestAndCaptureData(task, newStatus, simulatedData);
+        const { capturedUpdatedData, tasks } = setupTestAndCaptureData(task, newStatus, simulatedData);
 
         // Assert
         expect(tasks).toEqual([]);
-        expect(mockFileWriter).toHaveBeenCalledTimes(1);
-        expect(mockFileWriter).toHaveBeenCalledWith('archive.md', expect.any(Function));
         expect(capturedUpdatedData).toBe(`- [x] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10 ✅ 2024-02-11
 `);
     });

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -321,6 +321,17 @@ describe('OnCompletion-ToLogFile', () => {
 
         // Check that mockFileWriter was called with the correct arguments
         expect(mockFileWriter).toHaveBeenCalledWith('archive.md', expect.any(Function));
+
+        // Check if mockFileWriter has been called
+        expect(mockFileWriter.mock.calls.length).toBe(1);
+        // Retrieve the fileContentUpdater function passed to mockFileWriter
+        const fileContentUpdater = mockFileWriter.mock.calls[0][1];
+
+        // Now simulate calling fileContentUpdater to check its behavior
+        const initiallyEmptyLogFile = '';
+        const updatedData = fileContentUpdater(initiallyEmptyLogFile);
+        expect(updatedData).toEqual(`- [x] A non-recurring task with 🏁 ToLogFile 📅 2024-02-10 ✅ 2024-02-11
+`);
     });
 });
 

--- a/tests/Task/OnCompletion.test.ts
+++ b/tests/Task/OnCompletion.test.ts
@@ -294,6 +294,15 @@ describe('OnCompletion-Delete', () => {
     });
 });
 
+export function applyStatusAndOnCompletionAction2(
+    task: Task,
+    newStatus: Status,
+    fileWriter: (filePath: string, fileContentUpdater: (data: string) => string) => void,
+) {
+    const tasks = task.handleNewStatus(newStatus);
+    return handleOnCompletion(task, tasks, 'archive.md', fileWriter);
+}
+
 describe('OnCompletion-ToLogFile', () => {
     it('should write completed instance of non-recurring task to empty log file', () => {
         // Arrange
@@ -301,11 +310,17 @@ describe('OnCompletion-ToLogFile', () => {
         const task = new TaskBuilder().description('A non-recurring task with 🏁 ToLogFile').dueDate(dueDate).build();
         expect(task.status.type).toEqual(StatusType.TODO);
 
+        // Create a Jest spy for the file writer
+        const mockFileWriter = jest.fn((_filePath: string, _fileContentUpdater: (data: string) => string) => {});
+
         // Act
-        const tasks = applyStatusAndOnCompletionAction(task, Status.makeDone());
+        const tasks = applyStatusAndOnCompletionAction2(task, Status.makeDone(), mockFileWriter);
 
         // Assert
         expect(tasks).toEqual([]);
+
+        // Check that mockFileWriter was called with the correct arguments
+        expect(mockFileWriter).toHaveBeenCalledWith('archive.md', expect.any(Function));
     });
 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description

Add mock file writer to inspect outputs of '🏁 ToLogFile' facility.

## Motivation

- To test code that is called on Obsidian objects.

## How has this been tested?

- With new tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

Internal changes:

- [x] **Tests** (prefix: `test` - additions and improvements to unit tests and the smoke tests)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project and passes `yarn run lint`.

## Terms

<!--
By submitting this pull request, you must agree to follow our
[contributing guide](https://publish.obsidian.md/tasks-contributing) and
[Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md).
Put an x in the boxes to confirm you agree.
-->

- [x] My contribution follow this project's [contributing guide](https://publish.obsidian.md/tasks-contributing)
- [x] I agree to follow this project's [Code of Conduct](https://github.com/obsidian-tasks-group/obsidian-tasks/blob/main/CODE_OF_CONDUCT.md)
